### PR TITLE
Update for CAN_FD support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,37 +1,53 @@
 {
-  "name": "node-red-contrib-socketcan",
-  "version": "1.0.10",
-  "description": "node-red nodes for socketcan",
+  "_from": "node-red-contrib-socketcan@1.0.9",
+  "_id": "node-red-contrib-socketcan@1.0.9",
+  "_inBundle": false,
+  "_integrity": "sha512-4JGpt1P3uaoXh6f31DpqQWSaSrFUKnp2hy61Kh4rrVgDABZBOnmAFgjko9L73t1fgZWX7MR9gGh3O2mfQPVaww==",
+  "_location": "/node-red-contrib-socketcan",
+  "_phantomChildren": {},
+  "_requested": {
+    "type": "version",
+    "registry": true,
+    "raw": "node-red-contrib-socketcan@1.0.9",
+    "name": "node-red-contrib-socketcan",
+    "escapedName": "node-red-contrib-socketcan",
+    "rawSpec": "1.0.9",
+    "saveSpec": null,
+    "fetchSpec": "1.0.9"
+  },
+  "_requiredBy": [
+    "#USER",
+    "/"
+  ],
+  "_resolved": "https://registry.npmjs.org/node-red-contrib-socketcan/-/node-red-contrib-socketcan-1.0.9.tgz",
+  "_shasum": "cb684eb9de44c4450c9f687c7b88d2dbf98724c8",
+  "_spec": "node-red-contrib-socketcan@1.0.9",
+  "_where": "/home/pi/.node-red",
+  "author": {
+    "name": "akhe@grodansparadis.com"
+  },
+  "bugs": {
+    "url": "https://github.com/grodansparadis/node-red-contrib-socketcan/issues"
+  },
+  "bundleDependencies": false,
   "dependencies": {
+    "bcrypt": ">=5.0.0",
     "minimist": "^1.2.5",
     "socketcan": "^2.8.0",
-    "util": "^0.12.3",
-    "bcrypt": ">=5.0.0"
+    "util": "^0.12.3"
   },
+  "deprecated": false,
+  "description": "node-red nodes for socketcan",
   "devDependencies": {
     "chai": "^4.2.0",
     "eslint": "^6.8.0",
     "mocha": "^7.2.0",
     "ncu": "^0.2.1",
-    "node-red": "^1.2.9",
+    "node-red": "^1.1.3",
     "node-red-contrib-mock-node": "^0.4.0",
     "node-red-node-test-helper": "^0.2.5",
     "npm-check-updates": "^4.1.2",
     "should": "^13.2.3"
-  },
-  "scripts": {
-    "start": "mkdir -p .node-red/node_modules && ln -sf $PWD $PWD/.node-red/node_modules/node-red-contrib-socketcan && node-red -u .node-red",
-    "lint": "eslint .",
-    "update-dependencies": "ncu -u && npm install"
-  },
-  "author": "akhe@grodansparadis.com",
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/grodansparadis/node-red-contrib-socketcan"
-  },
-  "bugs": {
-    "url": "https://github.com/grodansparadis/node-red-contrib-socketcan/issues"
   },
   "homepage": "https://github.com/grodansparadis/node-red-contrib-socketcan",
   "keywords": [
@@ -45,11 +61,23 @@
     "iot",
     "m2m"
   ],
+  "license": "MIT",
+  "name": "node-red-contrib-socketcan",
   "node-red": {
     "nodes": {
       "cansend": "src/send.js",
       "canreceive": "src/receive.js",
       "canconfig": "src/config.js"
     }
-  }
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/grodansparadis/node-red-contrib-socketcan.git"
+  },
+  "scripts": {
+    "lint": "eslint .",
+    "start": "mkdir -p .node-red/node_modules && ln -sf $PWD $PWD/.node-red/node_modules/node-red-contrib-socketcan && node-red -u .node-red",
+    "update-dependencies": "ncu -u && npm install"
+  },
+  "version": "1.0.9"
 }

--- a/src/receive.js
+++ b/src/receive.js
@@ -91,8 +91,13 @@ module.exports = function(RED) {
 				msg.payload.canid     = frame.id; 
 				msg.payload.dlc       = frame.data.length;
 				msg.payload.rtr       = frame.rtr || false;
+				msg.payload.canfd_capable	  = frame.canfd ||false;				// GT modif
 				msg.payload.data = [];
 				//msg.payload.data.push(frame.data);
+				
+				// GT MODIF
+				// Check if data are from CAN_FD frame
+					
 				msg.payload.data =  Array.prototype.slice.call(frame.data, 0);
 				node.send(msg);
 			});

--- a/src/receive.js
+++ b/src/receive.js
@@ -91,12 +91,8 @@ module.exports = function(RED) {
 				msg.payload.canid     = frame.id; 
 				msg.payload.dlc       = frame.data.length;
 				msg.payload.rtr       = frame.rtr || false;
-				msg.payload.canfd_capable	  = frame.canfd ||false;				// GT modif
 				msg.payload.data = [];
 				//msg.payload.data.push(frame.data);
-				
-				// GT MODIF
-				// Check if data are from CAN_FD frame
 					
 				msg.payload.data =  Array.prototype.slice.call(frame.data, 0);
 				node.send(msg);

--- a/src/send.html
+++ b/src/send.html
@@ -47,7 +47,7 @@
 
 <!-- Next, some simple help text is provided for the node.                   -->
 <script type="text/x-red" data-help-name="socketcan-in">
-   <p><b>socketcan-in</b> node is provided for sending CAN frames. You can send standard or extended id frames but currently not FD frames. 
+   <p><b>socketcan-in</b> node is provided for sending CAN frames. You can send standard or extended id frames , FD frames are supported. 
 
     Set up the interface to some real CAN hardware or use a virtual interface.</p>
 
@@ -61,6 +61,7 @@
 
 <pre>
 {
+    "canfd":false,
     "ext":false,
     "rtr":false,
     "canid":123,
@@ -69,6 +70,7 @@
 }
 </pre>
             <ul>     
+                <li> <b>canfd</b> - Define if the frame must be send as CANFD frame (if supported).</li>
                 <li> <b>ext</b> - Marks the message as an extended id message.</li>
                 <li> <b>rtr</b> - The message is a remote transmission request. No data should be specified in this case (set to null).</li>
                 <li> <b>canid</b> - The canid for the CAN message. Must be less then 0x7ff for a standard CAN message.</li>
@@ -96,6 +98,8 @@
 5AA#         - Standard frame no data
 1F334455#1122334455667788 - extended frame
 123#R         - for remote transmission request.
+123##         - FD frame no data
+123##AA       - FD frame standard
 </pre>
             </p>
         </dd>

--- a/src/send.js
+++ b/src/send.js
@@ -73,7 +73,6 @@ module.exports = function(RED) {
 		}
 
 		if ( sock ) {
-			var FlagCanFD=false;
 			sock.start();
 
 			// Tell the world we are on the job

--- a/src/send.js
+++ b/src/send.js
@@ -73,7 +73,7 @@ module.exports = function(RED) {
 		}
 
 		if ( sock ) {
-			var FlagCanFD=false;				// GT modif	
+			var FlagCanFD=false;
 			sock.start();
 
 			// Tell the world we are on the job
@@ -101,12 +101,12 @@ module.exports = function(RED) {
 					frame.id    |= (msg.payload.ext ? 1 : 0) << 31;
 					frame.dlc    = 0;
 					frame.data   = null;
-					frame.canfd  = msg.payload.canfd || 0;;					// GT modif
+					frame.canfd  = msg.payload.canfd || 0;
 					
 					// remote transmission request does not have any data
 					if ( !msg.payload.rtr ) {								
 						frame.dlc    = msg.payload.dlc || 0;
-						if (!frame.canfd){									// GT modif
+						if (!frame.canfd){
 							if ( frame.dlc > 8 ) {
 								if (done) {
 									// Node-RED 1.0 compatible
@@ -166,7 +166,7 @@ module.exports = function(RED) {
 						// throw(new Error("CAN FD is not supported yet"));
 						 frame.id  = parseInt(msg.payload.split("##")[0],16);
 						 debuglog("frame.id " + frame.id);
-						 frame.canfd = true;									// GT modif	
+						 frame.canfd = true;	
 						 let data     = msg.payload.split("##")[1];
 						 debuglog("data " + data);
 						 frame.data   = Buffer.from(data,"hex");
@@ -235,21 +235,12 @@ module.exports = function(RED) {
 							" ext:"  + frame.ext +
 							" rtr:"  + frame.rtr );
 				// for CAN_FD we need to fulfill the buffer to have 4 bytes when DLC > 8
-				//var datafilling=frame.dlc;							//GT MODIF
-				if (frame.dlc>8){										//GT MODIF
-					if (frame.dlc %4 > 0)								//GT MODIF
-					{
-						var extension = (4 - (frame.dlc%4));			//GT MODIF : how many data to add
-						frame.dlc = frame.dlc + extension;				//GT MODIF : define the next size of the DLC
-						frame.data = Buffer.concat([frame.data ,Buffer.alloc(extension)],frame.dlc); 	// Fill empty data with null				
-					}
-				}				
+				//var datafilling=frame.dlc;
 
-				
 				// Send the CAN frame			 	
 				try {
-						if (frame.canfd) sock.sendFD( frame );		//GT MODIF
-						else sock.send( frame );					//GT MODIF
+						if (frame.canfd) sock.sendFD( frame );
+						else sock.send( frame );
 					}
 					catch (err) {
 						if (done) {

--- a/src/send.js
+++ b/src/send.js
@@ -159,7 +159,7 @@ module.exports = function(RED) {
 					// <can_id>##<flags>{data}
 					// for CAN FD frames
 					if( msg.payload && 
-						(msg.payload.indexOf("##") != -1 ) ) {   				// CAN FD frame
+						(msg.payload.indexOf("##") != -1 ) ) {
 						debuglog("FD Frame");
 						// throw(new Error("CAN FD is not supported yet"));
 						 frame.id  = parseInt(msg.payload.split("##")[0],16);

--- a/src/send.js
+++ b/src/send.js
@@ -89,7 +89,6 @@ module.exports = function(RED) {
 				var frame={};
 				frame.ext = false;
 				frame.rtr = false;
-			
 
 				if ( typeof msg.payload == 'object' ) {
 


### PR DESCRIPTION
Hello,
In parallel with this update I sent a pull request to integrate the SendFd() function on the native Node-red Can driver.
The modification added is to support the CAN_FD frame up to 64 data bytes.
If the length is >8 bytes so the driver will send the frame based on CANFD format.

For the payload, if the ## is detected so the send_FD() function will be used.
I add also a flag (option) to inform the user if his interface support the CAN_FD frame.

It's possible now to receive also up to 64 date Bytes.
Help have been updated as well (for the send function only)

Tested and used since 2 weeks on my project with up to 3 interfaces (CAN0, CAN1 & CAN2) without any troubles.

The modification not impact the current flow and no update is needed by if you agree my modifications.
Regards